### PR TITLE
Return shared_ptr in requirements()

### DIFF
--- a/src/check_fnis_en.ts
+++ b/src/check_fnis_en.ts
@@ -4,56 +4,61 @@
 <context>
     <name>CheckFNIS</name>
     <message>
-        <location filename="checkfnis.cpp" line="79"/>
+        <location filename="checkfnis.cpp" line="74"/>
+        <source>FNIS Checker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="checkfnis.cpp" line="84"/>
         <source>Checks if FNIS behaviours need to be updated whenever you start the game. This is only relevant for Skyrim and if FNIS is installed.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="211"/>
+        <location filename="checkfnis.cpp" line="216"/>
         <source>Run FNIS before %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="212"/>
+        <location filename="checkfnis.cpp" line="217"/>
         <source>FNIS source data has been changed. You should run GenerateFNIS.exe now.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="219"/>
+        <location filename="checkfnis.cpp" line="224"/>
         <source>Failed to start %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="225"/>
-        <location filename="checkfnis.cpp" line="232"/>
-        <location filename="checkfnis.cpp" line="256"/>
+        <location filename="checkfnis.cpp" line="230"/>
+        <location filename="checkfnis.cpp" line="237"/>
+        <location filename="checkfnis.cpp" line="261"/>
         <source>Start %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="226"/>
+        <location filename="checkfnis.cpp" line="231"/>
         <source>FNIS reported a %1, do you want to run the application anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="227"/>
-        <location filename="checkfnis.cpp" line="258"/>
+        <location filename="checkfnis.cpp" line="232"/>
+        <location filename="checkfnis.cpp" line="263"/>
         <source>warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="228"/>
-        <location filename="checkfnis.cpp" line="259"/>
+        <location filename="checkfnis.cpp" line="233"/>
+        <location filename="checkfnis.cpp" line="264"/>
         <source>critical error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="233"/>
+        <location filename="checkfnis.cpp" line="238"/>
         <source>Failed to determine FNIS exit code, do you want to run the application anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="257"/>
+        <location filename="checkfnis.cpp" line="262"/>
         <source>FNIS reported a %1. Do you want to assume it worked?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/check_fnis_en.ts
+++ b/src/check_fnis_en.ts
@@ -4,61 +4,56 @@
 <context>
     <name>CheckFNIS</name>
     <message>
-        <location filename="checkfnis.cpp" line="74"/>
-        <source>FNIS Checker</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="checkfnis.cpp" line="84"/>
+        <location filename="checkfnis.cpp" line="79"/>
         <source>Checks if FNIS behaviours need to be updated whenever you start the game. This is only relevant for Skyrim and if FNIS is installed.&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="216"/>
+        <location filename="checkfnis.cpp" line="211"/>
         <source>Run FNIS before %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="217"/>
+        <location filename="checkfnis.cpp" line="212"/>
         <source>FNIS source data has been changed. You should run GenerateFNIS.exe now.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="224"/>
+        <location filename="checkfnis.cpp" line="219"/>
         <source>Failed to start %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="230"/>
-        <location filename="checkfnis.cpp" line="237"/>
-        <location filename="checkfnis.cpp" line="261"/>
+        <location filename="checkfnis.cpp" line="225"/>
+        <location filename="checkfnis.cpp" line="232"/>
+        <location filename="checkfnis.cpp" line="256"/>
         <source>Start %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="231"/>
+        <location filename="checkfnis.cpp" line="226"/>
         <source>FNIS reported a %1, do you want to run the application anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="232"/>
-        <location filename="checkfnis.cpp" line="263"/>
+        <location filename="checkfnis.cpp" line="227"/>
+        <location filename="checkfnis.cpp" line="258"/>
         <source>warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="233"/>
-        <location filename="checkfnis.cpp" line="264"/>
+        <location filename="checkfnis.cpp" line="228"/>
+        <location filename="checkfnis.cpp" line="259"/>
         <source>critical error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="238"/>
+        <location filename="checkfnis.cpp" line="233"/>
         <source>Failed to determine FNIS exit code, do you want to run the application anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="checkfnis.cpp" line="262"/>
+        <location filename="checkfnis.cpp" line="257"/>
         <source>FNIS reported a %1. Do you want to assume it worked?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/checkfnis.cpp
+++ b/src/checkfnis.cpp
@@ -91,7 +91,7 @@ VersionInfo CheckFNIS::version() const
 }
 
 
-QList<IPluginRequirement*> CheckFNIS::requirements() const
+std::vector<std::shared_ptr<const MOBase::IPluginRequirement>> CheckFNIS::requirements() const
 {
   return { Requirements::gameDependency("Skyrim") };
 }

--- a/src/checkfnis.h
+++ b/src/checkfnis.h
@@ -37,7 +37,7 @@ public: // IPlugin
   virtual bool init(MOBase::IOrganizer *moInfo) override;
   virtual QString name() const override;
   virtual QString localizedName() const override;
-  virtual QList<MOBase::IPluginRequirement*> requirements() const override;
+  virtual std::vector<std::shared_ptr<const MOBase::IPluginRequirement>> requirements() const override;
   virtual QString author() const override;
   virtual QString description() const override;
   virtual MOBase::VersionInfo version() const override;


### PR DESCRIPTION
As explained on Discord, I included this in the `listSaves()` PR because there are changes I need from this PR. The name of the branch is off to ease testing with `mob` or `umbrella`.